### PR TITLE
guzzle 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "nediam/phraseapp-bundle",
     "description": "Basic integration with phraseapp.com",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "license": "MIT",
     "authors": [
         {
@@ -15,6 +15,6 @@
         }
     },
     "require": {
-        "nediam/phraseapp-lib": ">=1.2 <2.0.0"
+        "nediam/phraseapp-lib": "^2.0"
     }
 }


### PR DESCRIPTION
# DO NOT REMOVE ~THIS PR~ BRANCH UNDER THIS PR

3.0-beta2 is tagged from a commit from this branch and it's used by `monolith-app` so if You remove this ~PR~ branch You will remove the commit under the tag and this will render 3.0-beta2 uninstallable